### PR TITLE
feat: temporarily disable ticket date

### DIFF
--- a/backend/resources/views/emails/orders/summary.blade.php
+++ b/backend/resources/views/emails/orders/summary.blade.php
@@ -13,7 +13,7 @@
 @if($order->isOrderAwaitingOfflinePayment() === false)
 
 <p>
-{{ __('Congratulations! Your order for :eventTitle on :eventDate at :eventTime was successful. Please find your order details below.', ['eventTitle' => $event->getTitle(), 'eventDate' => (new Carbon(DateHelper::convertFromUTC($event->getStartDate(), $event->getTimezone())))->format('F j, Y'), 'eventTime' => (new Carbon(DateHelper::convertFromUTC($event->getStartDate(), $event->getTimezone())))->format('g:i A')]) }}
+{{ __('Congratulations! Your order for the following ticket(s) was successful. Please find your order details below.') }}
 </p>
 
 @else
@@ -31,15 +31,6 @@
 </div>
 
 @endif
-
-<p>
-
-# {{ __('Event Details') }}
-**{{ __('Event Name:') }}** {{ $event->getTitle() }}
-    <br>
-**{{ __('Date & Time:') }}** {{ (new Carbon(DateHelper::convertFromUTC($event->getStartDate(), $event->getTimezone())))->format('F j, Y') }} at {{ (new Carbon(DateHelper::convertFromUTC($event->getStartDate(), $event->getTimezone())))->format('g:i A') }}
-
-</p>
 
 @if($eventSettings->getPostCheckoutMessage() && $order->isOrderCompleted())
 <p>

--- a/frontend/src/components/common/AttendeeTicket/index.tsx
+++ b/frontend/src/components/common/AttendeeTicket/index.tsx
@@ -45,9 +45,10 @@ export const AttendeeTicket = ({attendee, product, event, hideButtons = false}: 
                     <div className={classes.eventName}>
                         {event?.title}
                     </div>
-                    <div className={classes.eventDate}>
+                    {/* <div className={classes.eventDate}>
                         {prettyDate(event.start_date, event.timezone)}
-                    </div>
+                    </div> */}
+                    {/* Temporarily removed until support for recurring events is created */}
                 </div>
             </div>
             <div className={classes.qrCode}>

--- a/frontend/src/components/layouts/Checkout/index.tsx
+++ b/frontend/src/components/layouts/Checkout/index.tsx
@@ -106,7 +106,6 @@ const Checkout = () => {
                                                 hideShareButtonText={isMobile}
                                             />
 
-                                            <AddToEventCalendarButton event={event}/>
 
                                             {orderHasAttendees && (
                                                 <Tooltip label={t`Print Tickets`}>

--- a/frontend/src/components/routes/product-widget/OrderSummaryAndProducts/index.tsx
+++ b/frontend/src/components/routes/product-widget/OrderSummaryAndProducts/index.tsx
@@ -273,9 +273,6 @@ export const OrderSummaryAndProducts = () => {
 
                 {!!event?.settings?.post_checkout_message && <PostCheckoutMessage message={event.settings.post_checkout_message}/>}
 
-                <h1 className={classes.heading}>{t`Event Details`}</h1>
-                <EventDetails event={event}/>
-
                 {(order?.attendees && order.attendees.length > 0) && (
                     <Group justify="space-between" align="center">
                         <h1 className={classes.heading}>{t`Guests`}</h1>


### PR DESCRIPTION
Temporarily disable time & dates in ticket emails until recurring events are supported. This is due to the way that H&C adds tickets to their system currently. See: https://github.com/HiEventsDev/Hi.Events/issues/713